### PR TITLE
Intruduced basic CMake configuration

### DIFF
--- a/BoostTypeTraitsConfig.cmake
+++ b/BoostTypeTraitsConfig.cmake
@@ -1,0 +1,9 @@
+# Copyright 2018 Thomas Jandecka
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
+include(CMakeFindDependencyMacro)
+find_dependency(BoostConfig 1.66)
+find_dependency(BoostCore 1.66)
+find_dependency(BoostStaticAssert 1.66)
+include("${CMAKE_CURRENT_LIST_DIR}/BoostTypeTraitsTargets.cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,52 @@
+# Copyright 2018 Thomas Jandecka
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
+cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+
+project(BoostTypeTraits VERSION 1.66 LANGUAGES CXX)
+
+add_library(type_traits INTERFACE)
+
+target_include_directories(type_traits INTERFACE 
+    $<BUILD_INTERFACE:${BoostTypeTraits_BINARY_DIR}/include>
+    $<BUILD_INTERFACE:${BoostTypeTraits_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+    )
+
+find_package(BoostConfig 1.66 REQUIRED)
+find_package(BoostCore 1.66 REQUIRED)
+find_package(BoostStaticAssert 1.66 REQUIRED)
+
+target_link_libraries(type_traits
+    INTERFACE
+        Boost::config
+        Boost::core
+        Boost::static_assert
+    )
+
+install(EXPORT type_traits-targets
+    FILE BoostTypeTraitsTargets.cmake
+    NAMESPACE Boost::
+    DESTINATION lib/cmake/boost
+    )
+
+install(TARGETS type_traits EXPORT type_traits-targets
+    INCLUDES DESTINATION include
+    )
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file("BoostTypeTraitsConfigVersion.cmake"
+    VERSION ${BoostTypeTraits_VERSION}
+    COMPATIBILITY SameMajorVersion
+    )
+install(
+    FILES
+        "BoostTypeTraitsConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/BoostTypeTraitsConfigVersion.cmake"
+    DESTINATION
+        lib/cmake/boost
+    )
+install(DIRECTORY include/ DESTINATION include)
+
+add_library(Boost::type_traits ALIAS type_traits)


### PR DESCRIPTION
Expresses Boost::type_traits as an `INTERFACE` library in CMake.
- use via `add_subdirectory` 
- use via `find_package(BoostTypeTraits 1.66)` if previously installed. This is achieved via the following install:
```
$INSTALL_PREFIX
├── include
│   └── boost
│       ├── aligned_storage.hpp
│       ├── type_traits
│       │   ├── add_const.hpp
│       │   ├── add_cv.hpp
│       │   ├── add_lvalue_reference.hpp
│       │   ├── add_pointer.hpp
│       │   ├── add_reference.hpp
│       │   ├── add_rvalue_reference.hpp
│       │   ├── add_volatile.hpp
│       │   ├── aligned_storage.hpp
│       │   ├── alignment_of.hpp
│       │   ├── alignment_traits.hpp
│       │   ├── arithmetic_traits.hpp
│       │   ├── array_traits.hpp
│       │   ├── broken_compiler_spec.hpp
│       │   ├── common_type.hpp
│       │   ├── composite_traits.hpp
│       │   ├── conditional.hpp
│       │   ├── config.hpp
│       │   ├── conversion_traits.hpp
│       │   ├── copy_cv.hpp
│       │   ├── cv_traits.hpp
│       │   ├── decay.hpp
│       │   ├── declval.hpp
│       │   ├── detail
│       │   │   ├── bool_trait_def.hpp
│       │   │   ├── bool_trait_undef.hpp
│       │   │   ├── common_arithmetic_type.hpp
│       │   │   ├── common_type_impl.hpp
│       │   │   ├── composite_member_pointer_type.hpp
│       │   │   ├── composite_pointer_type.hpp
│       │   │   ├── config.hpp
│       │   │   ├── has_binary_operator.hpp
│       │   │   ├── has_postfix_operator.hpp
│       │   │   ├── has_prefix_operator.hpp
│       │   │   ├── ice_and.hpp
│       │   │   ├── ice_eq.hpp
│       │   │   ├── ice_not.hpp
│       │   │   ├── ice_or.hpp
│       │   │   ├── is_function_ptr_helper.hpp
│       │   │   ├── is_function_ptr_tester.hpp
│       │   │   ├── is_mem_fun_pointer_impl.hpp
│       │   │   ├── is_mem_fun_pointer_tester.hpp
│       │   │   ├── mp_defer.hpp
│       │   │   ├── template_arity_spec.hpp
│       │   │   └── yes_no_type.hpp
│       │   ├── extent.hpp
│       │   ├── floating_point_promotion.hpp
│       │   ├── function_traits.hpp
│       │   ├── has_bit_and_assign.hpp
│       │   ├── has_bit_and.hpp
│       │   ├── has_bit_or_assign.hpp
│       │   ├── has_bit_or.hpp
│       │   ├── has_bit_xor_assign.hpp
│       │   ├── has_bit_xor.hpp
│       │   ├── has_complement.hpp
│       │   ├── has_dereference.hpp
│       │   ├── has_divides_assign.hpp
│       │   ├── has_divides.hpp
│       │   ├── has_equal_to.hpp
│       │   ├── has_greater_equal.hpp
│       │   ├── has_greater.hpp
│       │   ├── has_left_shift_assign.hpp
│       │   ├── has_left_shift.hpp
│       │   ├── has_less_equal.hpp
│       │   ├── has_less.hpp
│       │   ├── has_logical_and.hpp
│       │   ├── has_logical_not.hpp
│       │   ├── has_logical_or.hpp
│       │   ├── has_minus_assign.hpp
│       │   ├── has_minus.hpp
│       │   ├── has_modulus_assign.hpp
│       │   ├── has_modulus.hpp
│       │   ├── has_multiplies_assign.hpp
│       │   ├── has_multiplies.hpp
│       │   ├── has_negate.hpp
│       │   ├── has_new_operator.hpp
│       │   ├── has_not_equal_to.hpp
│       │   ├── has_nothrow_assign.hpp
│       │   ├── has_nothrow_constructor.hpp
│       │   ├── has_nothrow_copy.hpp
│       │   ├── has_nothrow_destructor.hpp
│       │   ├── has_operator.hpp
│       │   ├── has_plus_assign.hpp
│       │   ├── has_plus.hpp
│       │   ├── has_post_decrement.hpp
│       │   ├── has_post_increment.hpp
│       │   ├── has_pre_decrement.hpp
│       │   ├── has_pre_increment.hpp
│       │   ├── has_right_shift_assign.hpp
│       │   ├── has_right_shift.hpp
│       │   ├── has_trivial_assign.hpp
│       │   ├── has_trivial_constructor.hpp
│       │   ├── has_trivial_copy.hpp
│       │   ├── has_trivial_destructor.hpp
│       │   ├── has_trivial_move_assign.hpp
│       │   ├── has_trivial_move_constructor.hpp
│       │   ├── has_unary_minus.hpp
│       │   ├── has_unary_plus.hpp
│       │   ├── has_virtual_destructor.hpp
│       │   ├── ice.hpp
│       │   ├── integral_constant.hpp
│       │   ├── integral_promotion.hpp
│       │   ├── intrinsics.hpp
│       │   ├── is_abstract.hpp
│       │   ├── is_arithmetic.hpp
│       │   ├── is_array.hpp
│       │   ├── is_assignable.hpp
│       │   ├── is_base_and_derived.hpp
│       │   ├── is_base_of.hpp
│       │   ├── is_base_of_tr1.hpp
│       │   ├── is_class.hpp
│       │   ├── is_complex.hpp
│       │   ├── is_compound.hpp
│       │   ├── is_const.hpp
│       │   ├── is_constructible.hpp
│       │   ├── is_convertible.hpp
│       │   ├── is_copy_assignable.hpp
│       │   ├── is_copy_constructible.hpp
│       │   ├── is_default_constructible.hpp
│       │   ├── is_destructible.hpp
│       │   ├── is_empty.hpp
│       │   ├── is_enum.hpp
│       │   ├── is_final.hpp
│       │   ├── is_float.hpp
│       │   ├── is_floating_point.hpp
│       │   ├── is_function.hpp
│       │   ├── is_fundamental.hpp
│       │   ├── is_integral.hpp
│       │   ├── is_lvalue_reference.hpp
│       │   ├── is_member_function_pointer.hpp
│       │   ├── is_member_object_pointer.hpp
│       │   ├── is_member_pointer.hpp
│       │   ├── is_nothrow_move_assignable.hpp
│       │   ├── is_nothrow_move_constructible.hpp
│       │   ├── is_object.hpp
│       │   ├── is_pod.hpp
│       │   ├── is_pointer.hpp
│       │   ├── is_polymorphic.hpp
│       │   ├── is_reference.hpp
│       │   ├── is_rvalue_reference.hpp
│       │   ├── is_same.hpp
│       │   ├── is_scalar.hpp
│       │   ├── is_signed.hpp
│       │   ├── is_stateless.hpp
│       │   ├── is_union.hpp
│       │   ├── is_unsigned.hpp
│       │   ├── is_virtual_base_of.hpp
│       │   ├── is_void.hpp
│       │   ├── is_volatile.hpp
│       │   ├── make_signed.hpp
│       │   ├── make_unsigned.hpp
│       │   ├── make_void.hpp
│       │   ├── object_traits.hpp
│       │   ├── promote.hpp
│       │   ├── rank.hpp
│       │   ├── reference_traits.hpp
│       │   ├── remove_all_extents.hpp
│       │   ├── remove_bounds.hpp
│       │   ├── remove_const.hpp
│       │   ├── remove_cv.hpp
│       │   ├── remove_cv_ref.hpp
│       │   ├── remove_extent.hpp
│       │   ├── remove_pointer.hpp
│       │   ├── remove_reference.hpp
│       │   ├── remove_volatile.hpp
│       │   ├── same_traits.hpp
│       │   ├── transform_traits.hpp
│       │   ├── type_identity.hpp
│       │   └── type_with_alignment.hpp
│       ├── type_traits.hpp
│       └── utility
│           └── declval.hpp
└── lib
    └── cmake
        └── boost
            ├── BoostTypeTraitsConfig.cmake
            ├── BoostTypeTraitsConfigVersion.cmake
            └── BoostTypeTraitsTargets.cmake

8 directories, 173 files
```
- tests are __not__ included in the build